### PR TITLE
Modal sem ocupar toda a tela

### DIFF
--- a/src/components/patterns/FormCadastro/index.js
+++ b/src/components/patterns/FormCadastro/index.js
@@ -89,7 +89,7 @@ export default function FormCadastro({ propsDoModal }) {
         display="flex"
         paddingRight={{ md: '0' }}
         flex={1}
-        value={{ xs: 12, md: 5, lg: 4 }}
+        value={{ xs: 10, md: 5, lg: 4 }}
       >
         <Box
           boxShadow="-10px 0px 24px rgba(7, 12, 14, 0.1)"


### PR DESCRIPTION
A não ocupação da tela inteira é bom para podermos clicar fora do modal para fechá-lo.
Sei que foi passado o desafio para criar um botão para fechar, mas fazer isso é complicado. Já mexi no código e depois ao acompanhar a aula e ir copiando o código do Git deu muito errado. Tive que fazer a cópia de tudo para fazer funcionar. Então não vou mais tentar fazer algo que possa ter que desfazer. Esses desafios deixarei para o meu projeto.