### PR TITLE
Opacidade maior do Wrapper do modal

### DIFF
--- a/src/components/commons/Modal/index.js
+++ b/src/components/commons/Modal/index.js
@@ -7,7 +7,7 @@ const ModalWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  background: rgba(0,0,0,0.1);
+  background: rgba(0,0,0,0.5);
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
Acredito que uma opacidade maior do wrapper fica melhor, pois assim fica mais claro que a tela de baixo não faz parte do modal e evita cliques indevidos.